### PR TITLE
Wdm driver version and architecture config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ We have plans to support:
 5. Create new Pull Request
 
 <span>
-* Developers: [Dave Bassan](https://github.com/davebassan), [Tim Myerscough](https://github.com/temyers), [Christina Daskalaki](https://github.com/chdask), [Amit Sharma](https://github.com/amitsha), [Miles Lord](https://github.com/mplord), [Hamish Tedeschi](https://github.com/MagenTysHamo)
+* Developers: [Dave Bassan](https://github.com/davebassan), [Tim Myerscough](https://github.com/temyers), [Christina Daskalaki](https://github.com/chdask), [Amit Sharma](https://github.com/amitsha), [Miles Lord](https://github.com/mplord), [Hamish Tedeschi](https://github.com/MagenTysHamo), [Kevin Bradwick](https://github.com/kevbradwick)
 
 Powered by [MagenTys](http://magentys.io)

--- a/webdriver-factory/pom.xml
+++ b/webdriver-factory/pom.xml
@@ -32,6 +32,7 @@
                     <suites>
                         io.magentys.cinnamon.webdriver.capabilities.CapabilitiesModelTest,
                         io.magentys.cinnamon.webdriver.capabilities.CinnamonCapabilitiesTest,
+                        io.magentys.cinnamon.webdriver.capabilities.DriverConfigSpec,
                         io.magentys.cinnamon.webdriver.factory.DriverRegistryTest,
                         io.magentys.cinnamon.webdriver.factory.WebDriverFactorySpec
                     </suites>

--- a/webdriver-factory/pom.xml
+++ b/webdriver-factory/pom.xml
@@ -17,8 +17,25 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <configuration>
+                    <suites>
+                        io.magentys.cinnamon.webdriver.capabilities.CapabilitiesModelTest,
+                        io.magentys.cinnamon.webdriver.capabilities.CinnamonCapabilitiesTest,
+                        io.magentys.cinnamon.webdriver.factory.DriverRegistryTest,
+                        io.magentys.cinnamon.webdriver.factory.WebDriverFactorySpec
+                    </suites>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -52,16 +69,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/KEYS.scala
+++ b/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/KEYS.scala
@@ -5,6 +5,7 @@ object Keys {
   val CAPABILITIES_PROFILES_KEY = "capabilities-profiles"
   val DEFAULTS = "defaults"
   val DRIVER_EXTRAS_KEY = "driverExtras"
+  val DRIVER_BINARY = "driverBinary"
   val CONFIG_FILE_EXTENSION = "webdriver.conf"
 
   //Expected By user

--- a/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/factory/WebDriverFactory.scala
+++ b/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/factory/WebDriverFactory.scala
@@ -3,6 +3,7 @@ package io.magentys.cinnamon.webdriver.factory
 import java.net.URL
 
 import io.github.bonigarcia.wdm.WebDriverManager
+import io.magentys.cinnamon.webdriver.capabilities.DriverBinaryConfig
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.{Capabilities, WebDriver}
 
@@ -10,14 +11,19 @@ import scala.util.Try
 
 object WebDriverFactory {
 
-  def getDriver(capabilities: Capabilities, hubURL: String = ""): WebDriver = {
+  def getDriver(capabilities: Capabilities, hubURL: String = "", binaryConfig: Option[DriverBinaryConfig] = None): WebDriver = {
     if (hubURL != null && hubURL.trim.nonEmpty) createRemoteWebDriver(capabilities, hubURL)
-    else createWebDriver(capabilities)
+    else createWebDriver(capabilities, binaryConfig)
   }
 
-  private def createWebDriver(capabilities: Capabilities): WebDriver = {
+  private def createWebDriver(capabilities: Capabilities, binaryConfig: Option[DriverBinaryConfig] = None): WebDriver = {
     val driverClass = DriverRegistry.getDriverClass(capabilities)
-    if (driverClass.isDefined) Try(WebDriverManager.getInstance(driverClass.get).setup())
+    if (driverClass.isDefined) {
+      binaryConfig match {
+        case Some(binConfig) => Try(WebDriverManager.getInstance(driverClass.get).setup(binConfig.arch, binConfig.version))
+        case None => Try(WebDriverManager.getInstance(driverClass.get).setup())
+      }
+    }
     DriverRegistry.locals.newInstance(capabilities)
   }
 

--- a/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/factory/WebDriverFactory.scala
+++ b/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/factory/WebDriverFactory.scala
@@ -2,31 +2,50 @@ package io.magentys.cinnamon.webdriver.factory
 
 import java.net.URL
 
-import io.github.bonigarcia.wdm.WebDriverManager
+import io.github.bonigarcia.wdm.{BrowserManager, WebDriverManager}
 import io.magentys.cinnamon.webdriver.capabilities.DriverBinaryConfig
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.{Capabilities, WebDriver}
 
 import scala.util.Try
 
-object WebDriverFactory {
+// helper interface around statics used in WebDriverManager
+private[factory] trait WebDriverManagerFactory {
+  def driverManagerClass(driverClass: Class[_ <: WebDriver]): BrowserManager = WebDriverManager.getInstance(driverClass)
+  def webDriver(capabilities: Capabilities): WebDriver = DriverRegistry.locals.newInstance(capabilities)
+}
 
-  def getDriver(capabilities: Capabilities, hubURL: String = "", binaryConfig: Option[DriverBinaryConfig] = None): WebDriver = {
-    if (hubURL != null && hubURL.trim.nonEmpty) createRemoteWebDriver(capabilities, hubURL)
-    else createWebDriver(capabilities, binaryConfig)
-  }
+class WebDriverFactory(factory: WebDriverManagerFactory) {
 
-  private def createWebDriver(capabilities: Capabilities, binaryConfig: Option[DriverBinaryConfig] = None): WebDriver = {
+  /**
+    * Create a new instance of a web driver
+    *
+    * @param capabilities the browser capabilities
+    * @param hubUrl       optional hub url
+    * @param binaryConfig optional driver binary configuration
+    * @return
+    */
+  def getDriver(capabilities: Capabilities, hubUrl: Option[String], binaryConfig: Option[DriverBinaryConfig]): WebDriver = {
+
+    // if a hub url has been passed in then ignore WDM and return an instance of remote web driver
+    if (hubUrl.isDefined && !hubUrl.get.isEmpty) {
+      return new RemoteWebDriver(new URL(hubUrl.get), capabilities)
+    }
+
     val driverClass = DriverRegistry.getDriverClass(capabilities)
+
     if (driverClass.isDefined) {
       binaryConfig match {
-        case Some(binConfig) => Try(WebDriverManager.getInstance(driverClass.get).setup(binConfig.arch, binConfig.version))
-        case None => Try(WebDriverManager.getInstance(driverClass.get).setup())
+        case Some(binConfig) => Try(factory.driverManagerClass(driverClass.get).setup(binConfig.arch, binConfig.version))
+        case None => Try(factory.driverManagerClass(driverClass.get).setup())
       }
     }
-    DriverRegistry.locals.newInstance(capabilities)
+
+    factory.webDriver(capabilities)
   }
 
-  private def createRemoteWebDriver(capabilities: Capabilities, hubURL: String): WebDriver =
-    new RemoteWebDriver(new URL(hubURL), capabilities)
+}
+
+object WebDriverFactory {
+  def apply() = new WebDriverFactory(new WebDriverManagerFactory {})
 }

--- a/webdriver-factory/src/test/resources/defaults-test.conf
+++ b/webdriver-factory/src/test/resources/defaults-test.conf
@@ -1,0 +1,72 @@
+//Expected by the user as system vars or env vars.
+browserProfile : ${?browserProfile}
+hubUrl : ${?hubUrl}
+webDriverConfig : ${?webDriverConfig}
+
+//And some generics
+reuse-browser-session: false
+
+//These are default configs that cinnamon applies for each driver.
+//They can be overridden by the user in capabilities profiles.
+capabilities-profiles {
+
+  //Will be set as Capabilities
+  ie {
+    browserName : "internet explorer"
+    driverExtras : {
+      "unexpectedAlertBehaviour" : "dismiss"
+      "ie.ensureCleanSession" : true
+      "ignoreZoomSetting" : true
+      "requireWindowFocus" : true
+      "enablePersistentHover" : false
+    }
+
+    driverBinary {
+      arch: "32"
+      version: "2.51"
+    }
+
+    properties : {
+      "webdriver.ie.driver" : ${?IE_DRIVER_PATH} #use export IE_DRIVER_PATH=/the/path
+    }
+  }
+
+  edge {
+    browserName : "MicrosoftEdge"
+    properties : {
+      "webdriver.edge.driver": ${?EDGE_DRIVER_PATH} #use export EDGE_DRIVER_PATH=/the/path
+    }
+  }
+
+  //Will be set in FirefoxProfile.setPreference
+  firefox {
+    browserName : "firefox"
+    driverExtras : {
+      "webdriver_accept_untrusted_certs": true
+      "webdriver_assume_untrusted_issuer": true
+    }
+  }
+
+  //Will be set in ChromeOptions
+  chrome {
+    browserName : "chrome"
+    properties : {
+      "webdriver.chrome.driver": ${?CHROME_DRIVER_PATH} #use export CHROME_DRIVER_PATH=/the/path
+    }
+  }
+
+  //Will be set in SafariOptions
+  safari {
+    browserName : "safari"
+    driverExtras : {
+      "setUseCleanSession" : true
+    }
+  }
+
+  phantomjs {
+    browserName : "phantomjs"
+    properties : {
+      "phantomjs.binary.path": ${?PHANTOMJS_BINARY_PATH} #use export PHANTOMJS_BINARY_PATH=/the/path
+    }
+  }
+}

--- a/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/capabilities/DriverConfigSpec.scala
+++ b/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/capabilities/DriverConfigSpec.scala
@@ -1,0 +1,35 @@
+package io.magentys.cinnamon.webdriver.capabilities
+
+import com.typesafe.config.{Config, ConfigFactory}
+import io.github.bonigarcia.wdm.Architecture
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+
+class DriverConfigSpec extends FunSpec with MockitoSugar with Matchers with BeforeAndAfterEach {
+
+  val config = ConfigFactory.load("defaults-test.conf")
+  val defaultConfig = mock[Config]
+
+  describe("DriverConfig") {
+    describe("When driver binary config is present") {
+      val driverConfig = DriverConfig("ie", config, "", config)
+      val binaryConfig = driverConfig.binaryConfig.get
+
+      it("has binary config if present in conf file") {
+        assert(driverConfig.binaryConfig.isDefined)
+      }
+
+      it("has the correct values as defined in the config file") {
+        assert(binaryConfig.arch == Architecture.x32)
+        assert(binaryConfig.version == "2.51")
+      }
+    }
+
+    describe("When driver binary config is not present") {
+      val driverConfig = DriverConfig("firefox", config, "", config)
+      it("does not have any driver binary configuration") {
+        assert(driverConfig.binaryConfig.isEmpty)
+      }
+    }
+  }
+}

--- a/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/factory/DriverRegistryTest.scala
+++ b/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/factory/DriverRegistryTest.scala
@@ -12,7 +12,7 @@ class DriverRegistryTest extends FlatSpec with Matchers with MockitoSugar{
   it should "handle new drivers added by user" in {
     val testCapabilities = new DesiredCapabilities("TEST", "", Platform.ANY)
     DriverRegistry.addDriverProvider(testCapabilities, classOf[ATestDriver].getName)
-    val actual: WebDriver = WebDriverFactory.getDriver(testCapabilities)
+    val actual: WebDriver = WebDriverFactory().getDriver(testCapabilities, None, None)
     actual shouldBe a [ATestDriver]
   }
 

--- a/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/factory/WebDriverFactorySpec.scala
+++ b/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/factory/WebDriverFactorySpec.scala
@@ -1,0 +1,54 @@
+package io.magentys.cinnamon.webdriver.factory
+
+import io.github.bonigarcia.wdm.{Architecture, BrowserManager}
+import io.magentys.cinnamon.webdriver.capabilities.DriverBinaryConfig
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, FunSpec, Matchers}
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+import org.openqa.selenium.remote.DesiredCapabilities
+import org.openqa.selenium.{Capabilities, WebDriver}
+import org.scalatest.mock.MockitoSugar
+
+class WebDriverFactorySpec extends FunSpec with MockitoSugar with Matchers with BeforeAndAfterEach {
+
+  var factoryMock: WebDriverManagerFactory = _
+  var browserManagerMock: BrowserManager = _
+  var webDriverFactory: WebDriverFactory = _
+  val capabilities = DesiredCapabilities.htmlUnit
+
+  override protected def beforeEach(): Unit = {
+    factoryMock = mock[WebDriverManagerFactory]
+    browserManagerMock = mock[BrowserManager]
+
+    when(factoryMock.driverManagerClass(any[Class[_ <: WebDriver]]))
+      .thenReturn(browserManagerMock)
+
+    webDriverFactory = new WebDriverFactory(factoryMock)
+  }
+
+  describe("WebDriverFactory") {
+    describe("getDriver()") {
+      it("calls WebDriverManager.setup() when no binary config supplied") {
+        webDriverFactory.getDriver(capabilities, Some(""), None)
+        verify(browserManagerMock).setup()
+      }
+
+      it("calls WebDriverManager.setup(arch, version) is binary config supplied") {
+        val binaryConfig = DriverBinaryConfig("2.51", Architecture.x32)
+        webDriverFactory.getDriver(capabilities, Some(""), Some(binaryConfig))
+        verify(browserManagerMock).setup(Architecture.x32, "2.51")
+      }
+
+      it("calls WebDriverFactory.webDriver()") {
+        webDriverFactory.getDriver(capabilities, Some(""), None)
+        verify(factoryMock).webDriver(capabilities)
+      }
+
+      it("WebDriverManager not used if driver class is unknown") {
+        webDriverFactory.getDriver(mock[Capabilities], Some(""), None)
+        verify(factoryMock, never()).driverManagerClass(any())
+      }
+    }
+  }
+
+}

--- a/webdriver/src/main/java/io/magentys/cinnamon/webdriver/EventHandlingWebDriverContainer.java
+++ b/webdriver/src/main/java/io/magentys/cinnamon/webdriver/EventHandlingWebDriverContainer.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -85,8 +86,8 @@ public class EventHandlingWebDriverContainer implements WebDriverContainer {
 
     private WebDriver createDriver() {
         DriverConfig driverConfig = CinnamonWebDriverConfig.driverConfig();
-        String remoteUrl = CinnamonWebDriverConfig.hubUrl();
-        return WebDriverFactory.getDriver(driverConfig.desiredCapabilities(), remoteUrl, driverConfig.binaryConfig());
+        Option<String> remoteUrl = Option.apply(CinnamonWebDriverConfig.hubUrl());
+        return WebDriverFactory.apply().getDriver(driverConfig.desiredCapabilities(), remoteUrl, driverConfig.binaryConfig());
     }
 
     private WindowTracker createWindowTracker() {

--- a/webdriver/src/main/java/io/magentys/cinnamon/webdriver/EventHandlingWebDriverContainer.java
+++ b/webdriver/src/main/java/io/magentys/cinnamon/webdriver/EventHandlingWebDriverContainer.java
@@ -86,7 +86,7 @@ public class EventHandlingWebDriverContainer implements WebDriverContainer {
     private WebDriver createDriver() {
         DriverConfig driverConfig = CinnamonWebDriverConfig.driverConfig();
         String remoteUrl = CinnamonWebDriverConfig.hubUrl();
-        return WebDriverFactory.getDriver(driverConfig.desiredCapabilities(), remoteUrl);
+        return WebDriverFactory.getDriver(driverConfig.desiredCapabilities(), remoteUrl, driverConfig.binaryConfig());
     }
 
     private WindowTracker createWindowTracker() {


### PR DESCRIPTION
Changes added to configure driver binary configuration that is eventually fed in to WebDriverManager. We can now add the following section to the browser config;

```
driverBinary {
    version: "2.51"
    arch: 32
}
```

Also fixed maven configuration so that it picks up the specs when running the test goal.