### PR TITLE
Env config parse bug

### DIFF
--- a/core/src/main/java/io/magentys/cinnamon/conf/Env.java
+++ b/core/src/main/java/io/magentys/cinnamon/conf/Env.java
@@ -55,8 +55,9 @@ public class Env {
     }
 
     private Config initConfig() {
+        Config systemConfig = ConfigFactory.systemProperties();
         File envConfig = searchConfigFileInClasspath(ConfigConstants.ENV_CONF_FILE);
-        return ConfigFactory.parseFile(envConfig).getConfig(env).resolve();
+        return systemConfig.withFallback(ConfigFactory.parseFile(envConfig)).resolve().getConfig(env);
     }
 
     private File searchConfigFileInClasspath(String filename) {

--- a/core/src/test/java/io/magentys/cinnamon/conf/EnvTest.java
+++ b/core/src/test/java/io/magentys/cinnamon/conf/EnvTest.java
@@ -7,25 +7,22 @@ import static org.junit.Assert.assertEquals;
 
 public class EnvTest {
 
+    private Env env;
+
     @Before
     public void setUp() {
         System.setProperty("env", "example");
+        System.setProperty("example.host", "foobar");
+        env = Env.INSTANCE;
     }
 
     @Test
     public void testSystemPropertySubstitutionWorks() {
-        System.setProperty("example.host", "foobar");
-
-        Env env = Env.INSTANCE;
         assertEquals("foobar", env.config.getString("host"));
-
-        System.clearProperty("env");
-        System.clearProperty("example.host");
     }
 
     @Test
     public void testDefaultValueOfConfigItemWhenNoSystemPropertyOverrideIsSet() {
-        Env env = Env.INSTANCE;
         assertEquals(8080, env.config.getInt("port"));
     }
 }

--- a/core/src/test/java/io/magentys/cinnamon/conf/EnvTest.java
+++ b/core/src/test/java/io/magentys/cinnamon/conf/EnvTest.java
@@ -1,0 +1,20 @@
+package io.magentys.cinnamon.conf;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnvTest {
+
+    @Test
+    public void testSystemPropertySubstitutionWorks() {
+        System.setProperty("env", "example");
+        System.setProperty("example.host", "foobar");
+
+        Env env = Env.INSTANCE;
+        assertEquals("foobar", env.config.getString("host"));
+
+        System.clearProperty("env");
+        System.clearProperty("example.host");
+    }
+}

--- a/core/src/test/java/io/magentys/cinnamon/conf/EnvTest.java
+++ b/core/src/test/java/io/magentys/cinnamon/conf/EnvTest.java
@@ -1,14 +1,19 @@
 package io.magentys.cinnamon.conf;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class EnvTest {
 
+    @Before
+    public void setUp() {
+        System.setProperty("env", "example");
+    }
+
     @Test
     public void testSystemPropertySubstitutionWorks() {
-        System.setProperty("env", "example");
         System.setProperty("example.host", "foobar");
 
         Env env = Env.INSTANCE;
@@ -16,5 +21,11 @@ public class EnvTest {
 
         System.clearProperty("env");
         System.clearProperty("example.host");
+    }
+
+    @Test
+    public void testDefaultValueOfConfigItemWhenNoSystemPropertyOverrideIsSet() {
+        Env env = Env.INSTANCE;
+        assertEquals(8080, env.config.getInt("port"));
     }
 }

--- a/core/src/test/resources/env.conf
+++ b/core/src/test/resources/env.conf
@@ -1,3 +1,4 @@
 example {
   host: "http://localhost"
+  port: 8080
 }

--- a/core/src/test/resources/env.conf
+++ b/core/src/test/resources/env.conf
@@ -1,0 +1,3 @@
+example {
+  host: "http://localhost"
+}

--- a/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/config/CinnamonWebDriverConfig.scala
+++ b/webdriver-factory/src/main/scala/io/magentys/cinnamon/webdriver/config/CinnamonWebDriverConfig.scala
@@ -36,13 +36,15 @@ object CinnamonWebDriverConfig {
       }).toOption
     }
 
-    if (configFile.isDefined) {
-      val userConfig = ConfigFactory.parseFile(configFile.get).resolve()
-      userConfig.withFallback(defaultCinnamonConfig)
-    } else {
-      defaultCinnamonConfig
-    }
+    val systemPropertyConfig: Config = ConfigFactory.systemProperties()
 
+    configFile match {
+      case Some(file) =>
+        systemPropertyConfig
+          .withFallback(ConfigFactory.parseFile(file).resolve())
+          .withFallback(defaultCinnamonConfig)
+      case _ => systemPropertyConfig.withFallback(defaultCinnamonConfig)
+    }
   }
 
   val hubUrl = Try(config.getString(Keys.HUB_URL)).toOption.getOrElse("")

--- a/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/config/CinnamonWebDriverConfigTest.scala
+++ b/webdriver-factory/src/test/scala/io/magentys/cinnamon/webdriver/config/CinnamonWebDriverConfigTest.scala
@@ -1,0 +1,23 @@
+package io.magentys.cinnamon.webdriver.config
+
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+
+class CinnamonWebDriverConfigTest extends FunSpec with Matchers with BeforeAndAfterEach {
+
+  describe("CinnamonWebDriverConfig") {
+    it("Take system properties as overrides") {
+      val config = CinnamonWebDriverConfig.config
+      assert(config.getBoolean("reuse-browser-session"))
+    }
+  }
+
+  override protected def beforeEach(): Unit = {
+    System.setProperty("browserProfile", "chrome")
+    System.setProperty("reuse-browser-session", "true")
+  }
+
+  override protected def afterEach(): Unit = {
+    System.clearProperty("reuse-browser-session")
+    System.clearProperty("browserProfile")
+  }
+}


### PR DESCRIPTION
This fixes the issue whereby system properties were not used as a fallback when parsing the env file.